### PR TITLE
[MOSIP-44842] Add Manage MinIO Environment workflow

### DIFF
--- a/.github/workflows/manage-env.yml
+++ b/.github/workflows/manage-env.yml
@@ -58,7 +58,6 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             /repos/${{ github.repository }}/actions/variables/MINIO_ENVS \
             --jq '.value')
-
           echo "Current MINIO_ENVS: $CURRENT"
           echo "current=$CURRENT" >> $GITHUB_OUTPUT
 
@@ -71,14 +70,12 @@ jobs:
           CURRENT='${{ steps.read_envs.outputs.current }}'
           ENV_UPPER=$(echo "$ENV" | tr '[:lower:]' '[:upper:]')
 
-          # Check if env already exists — if so, skip variable update and only rotate secrets
           EXISTS=$(echo "$CURRENT" | jq --arg env "$ENV" 'map(select(. == $env)) | length')
 
           if [ "$EXISTS" -gt 0 ]; then
             echo "::warning::Environment '$ENV' already exists in MINIO_ENVS — variable unchanged. Secrets will be updated."
             echo "ENV_STATUS=updated" >> $GITHUB_ENV
           else
-            # Add env to the list and update the variable
             UPDATED=$(echo "$CURRENT" | jq --arg env "$ENV" '. + [$env]')
             echo "Updated MINIO_ENVS: $UPDATED"
             gh api \
@@ -89,61 +86,80 @@ jobs:
             echo "ENV_STATUS=added" >> $GITHUB_ENV
           fi
 
-          # Get repo public key for secret encryption
+          pip install PyNaCl -q
+
           KEY_DATA=$(gh api \
             -H "Accept: application/vnd.github+json" \
             /repos/${{ github.repository }}/actions/secrets/public-key)
           KEY_ID=$(echo "$KEY_DATA" | jq -r '.key_id')
           KEY=$(echo "$KEY_DATA" | jq -r '.key')
 
-          # Encrypt and create each secret using Python (libsodium via PyNaCl)
-          pip install PyNaCl -q
-
           encrypt_and_set() {
             SECRET_NAME=$1
             SECRET_VALUE=$2
-
-            ENCRYPTED=$(python3 - "$KEY" "$SECRET_VALUE" << 'PYEOF'
-import sys, base64
-from nacl import encoding, public
-
-key   = base64.b64decode(sys.argv[1])
-value = sys.argv[2].encode()
-box   = public.SealedBox(public.PublicKey(key))
-print(base64.b64encode(box.encrypt(value)).decode())
-PYEOF
-)
+            ENCRYPTED=$(python3 -c "import sys,base64;from nacl import public;k=base64.b64decode(sys.argv[1]);v=sys.argv[2].encode();print(base64.b64encode(public.SealedBox(public.PublicKey(k)).encrypt(v)).decode())" "$KEY" "$SECRET_VALUE")
             gh api \
               -X PUT \
               -H "Accept: application/vnd.github+json" \
               /repos/${{ github.repository }}/actions/secrets/$SECRET_NAME \
               -f encrypted_value="$ENCRYPTED" \
               -f key_id="$KEY_ID"
-
-            echo "Secret $SECRET_NAME created."
+            echo "Secret $SECRET_NAME set."
           }
 
           encrypt_and_set "MINIO_${ENV_UPPER}_URL"      "${{ inputs.minio_url }}"
           encrypt_and_set "MINIO_${ENV_UPPER}_USER"     "${{ inputs.minio_user }}"
           encrypt_and_set "MINIO_${ENV_UPPER}_PASSWORD" "${{ inputs.minio_password }}"
 
-          if [ "$ENV_STATUS" = "added" ]; then
-            echo "Environment '$ENV' added to MINIO_ENVS and secrets created."
-            echo "MINIO_ENVS is now: $UPDATED"
-          else
-            echo "Environment '$ENV' already existed — MINIO_ENVS unchanged. Secrets rotated."
-          fi
-
           echo "## Manage MinIO Environment" >> $GITHUB_STEP_SUMMARY
           if [ "$ENV_STATUS" = "added" ]; then
             echo "**Action:** Add" >> $GITHUB_STEP_SUMMARY
-            echo "**Environment:** \`$ENV\`" >> $GITHUB_STEP_SUMMARY
+            echo "**Environment:** $ENV" >> $GITHUB_STEP_SUMMARY
             echo "**Result:** Added to MINIO_ENVS and secrets created." >> $GITHUB_STEP_SUMMARY
           else
             echo "**Action:** Add (secret rotation)" >> $GITHUB_STEP_SUMMARY
-            echo "**Environment:** \`$ENV\`" >> $GITHUB_STEP_SUMMARY
-            echo "**Result:** \`$ENV\` already existed in MINIO_ENVS — variable was not modified. Secrets MINIO_${ENV_UPPER}_URL / _USER / _PASSWORD have been replaced." >> $GITHUB_STEP_SUMMARY
+            echo "**Environment:** $ENV" >> $GITHUB_STEP_SUMMARY
+            echo "**Result:** $ENV already existed — MINIO_ENVS unchanged. Secrets MINIO_${ENV_UPPER}_URL / _USER / _PASSWORD replaced." >> $GITHUB_STEP_SUMMARY
           fi
+
+      - name: Remove environment
+        if: inputs.action == 'remove'
+        env:
+          GH_TOKEN: ${{ secrets.MANAGE_ENV_TOKEN }}
+        run: |
+          ENV="${{ inputs.env_name }}"
+          CURRENT='${{ steps.read_envs.outputs.current }}'
+          ENV_UPPER=$(echo "$ENV" | tr '[:lower:]' '[:upper:]')
+
+          EXISTS=$(echo "$CURRENT" | jq --arg env "$ENV" 'map(select(. == $env)) | length')
+          if [ "$EXISTS" -eq 0 ]; then
+            echo "Environment '$ENV' not found in MINIO_ENVS. Nothing to do."
+            exit 1
+          fi
+
+          UPDATED=$(echo "$CURRENT" | jq --arg env "$ENV" 'map(select(. != $env))')
+          echo "Updated MINIO_ENVS: $UPDATED"
+
+          gh api \
+            -X PATCH \
+            -H "Accept: application/vnd.github+json" \
+            /repos/${{ github.repository }}/actions/variables/MINIO_ENVS \
+            -f value="$UPDATED"
+
+          for SUFFIX in URL USER PASSWORD; do
+            SECRET_NAME="MINIO_${ENV_UPPER}_${SUFFIX}"
+            gh api \
+              -X DELETE \
+              -H "Accept: application/vnd.github+json" \
+              /repos/${{ github.repository }}/actions/secrets/$SECRET_NAME \
+              && echo "Secret $SECRET_NAME deleted." \
+              || echo "Secret $SECRET_NAME not found, skipping."
+          done
+
+          echo "## Manage MinIO Environment" >> $GITHUB_STEP_SUMMARY
+          echo "**Action:** Remove" >> $GITHUB_STEP_SUMMARY
+          echo "**Environment:** $ENV" >> $GITHUB_STEP_SUMMARY
+          echo "**Result:** Removed from MINIO_ENVS and secrets deleted." >> $GITHUB_STEP_SUMMARY
 
       - name: Notify Slack
         if: always()
@@ -212,44 +228,3 @@ PYEOF
 
           curl -fsSL -X POST -H 'Content-type: application/json' \
                --data "$PAYLOAD" "$SLACK_WEBHOOK_URL"
-
-      - name: Remove environment
-        if: inputs.action == 'remove'
-        env:
-          GH_TOKEN: ${{ secrets.MANAGE_ENV_TOKEN }}
-        run: |
-          ENV="${{ inputs.env_name }}"
-          CURRENT='${{ steps.read_envs.outputs.current }}'
-          ENV_UPPER=$(echo "$ENV" | tr '[:lower:]' '[:upper:]')
-
-          # Check env exists
-          EXISTS=$(echo "$CURRENT" | jq --arg env "$ENV" 'map(select(. == $env)) | length')
-          if [ "$EXISTS" -eq 0 ]; then
-            echo "Environment '$ENV' not found in MINIO_ENVS. Nothing to do."
-            exit 1
-          fi
-
-          # Remove env from the list
-          UPDATED=$(echo "$CURRENT" | jq --arg env "$ENV" 'map(select(. != $env))')
-          echo "Updated MINIO_ENVS: $UPDATED"
-
-          # Update the variable
-          gh api \
-            -X PATCH \
-            -H "Accept: application/vnd.github+json" \
-            /repos/${{ github.repository }}/actions/variables/MINIO_ENVS \
-            -f value="$UPDATED"
-
-          # Delete the 3 secrets
-          for SUFFIX in URL USER PASSWORD; do
-            SECRET_NAME="MINIO_${ENV_UPPER}_${SUFFIX}"
-            gh api \
-              -X DELETE \
-              -H "Accept: application/vnd.github+json" \
-              /repos/${{ github.repository }}/actions/secrets/$SECRET_NAME \
-              && echo "Secret $SECRET_NAME deleted." \
-              || echo "Secret $SECRET_NAME not found, skipping."
-          done
-
-          echo "Environment '$ENV' removed successfully."
-          echo "MINIO_ENVS is now: $UPDATED"

--- a/.github/workflows/manage-env.yml
+++ b/.github/workflows/manage-env.yml
@@ -139,7 +139,13 @@ jobs:
           EXISTS=$(echo "$CURRENT" | jq --arg env "$ENV" 'map(select(. == $env)) | length')
           if [ "$EXISTS" -eq 0 ]; then
             echo "Environment '$ENV' not found in MINIO_ENVS. Nothing to do."
-            exit 1
+            echo "ENV_STATUS=not_found" >> $GITHUB_ENV
+
+            echo "## Manage MinIO Environment" >> $GITHUB_STEP_SUMMARY
+            echo "**Action:** Remove" >> $GITHUB_STEP_SUMMARY
+            echo "**Environment:** $ENV" >> $GITHUB_STEP_SUMMARY
+            echo "**Result:** Environment '$ENV' not found in MINIO_ENVS. Nothing to do." >> $GITHUB_STEP_SUMMARY
+            exit 0
           fi
 
           UPDATED=$(echo "$CURRENT" | jq --arg env "$ENV" 'map(select(. != $env))')
@@ -186,7 +192,11 @@ jobs:
             STEP_OUTCOME="$REMOVE_OUTCOME"
           fi
 
-          if [ "$STEP_OUTCOME" != "success" ]; then
+          if [ "${ENV_STATUS:-}" = "not_found" ]; then
+            ICON=":information_source:"
+            TITLE="MinIO Env Not Found"
+            DETAIL="Environment \`$ENV\` was not found in MINIO_ENVS. No changes were made."
+          elif [ "$STEP_OUTCOME" != "success" ]; then
             ICON=":warning:"
             TITLE="MinIO Env Change Failed"
             DETAIL="Action \`$ACTION\` for \`$ENV\` failed. Check the run for details."

--- a/.github/workflows/manage-env.yml
+++ b/.github/workflows/manage-env.yml
@@ -54,14 +54,18 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.MANAGE_ENV_TOKEN }}
         run: |
-          CURRENT=$(gh api \
+          RAW=$(gh api \
             -H "Accept: application/vnd.github+json" \
             /repos/${{ github.repository }}/actions/variables/MINIO_ENVS \
             --jq '.value')
+
+          # Compact to a single line so it writes cleanly to GITHUB_OUTPUT
+          CURRENT=$(echo "$RAW" | jq -c '.')
           echo "Current MINIO_ENVS: $CURRENT"
           echo "current=$CURRENT" >> $GITHUB_OUTPUT
 
       - name: Add environment
+        id: add_env
         if: inputs.action == 'add'
         env:
           GH_TOKEN: ${{ secrets.MANAGE_ENV_TOKEN }}
@@ -77,12 +81,12 @@ jobs:
             echo "ENV_STATUS=updated" >> $GITHUB_ENV
           else
             UPDATED=$(echo "$CURRENT" | jq --arg env "$ENV" '. + [$env]')
-            echo "Updated MINIO_ENVS: $UPDATED"
+            echo "Updated MINIO_ENVS: $(echo "$UPDATED" | jq -c '.')"
             gh api \
               -X PATCH \
               -H "Accept: application/vnd.github+json" \
               /repos/${{ github.repository }}/actions/variables/MINIO_ENVS \
-              -f value="$UPDATED"
+              -f value="$(echo "$UPDATED" | jq -c '.')"
             echo "ENV_STATUS=added" >> $GITHUB_ENV
           fi
 
@@ -123,6 +127,7 @@ jobs:
           fi
 
       - name: Remove environment
+        id: remove_env
         if: inputs.action == 'remove'
         env:
           GH_TOKEN: ${{ secrets.MANAGE_ENV_TOKEN }}
@@ -138,13 +143,13 @@ jobs:
           fi
 
           UPDATED=$(echo "$CURRENT" | jq --arg env "$ENV" 'map(select(. != $env))')
-          echo "Updated MINIO_ENVS: $UPDATED"
+          echo "Updated MINIO_ENVS: $(echo "$UPDATED" | jq -c '.')"
 
           gh api \
             -X PATCH \
             -H "Accept: application/vnd.github+json" \
             /repos/${{ github.repository }}/actions/variables/MINIO_ENVS \
-            -f value="$UPDATED"
+            -f value="$(echo "$UPDATED" | jq -c '.')"
 
           for SUFFIX in URL USER PASSWORD; do
             SECRET_NAME="MINIO_${ENV_UPPER}_${SUFFIX}"
@@ -165,6 +170,8 @@ jobs:
         if: always()
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          ADD_OUTCOME:    ${{ steps.add_env.outcome }}
+          REMOVE_OUTCOME: ${{ steps.remove_env.outcome }}
         run: |
           ACTION="${{ inputs.action }}"
           ENV="${{ inputs.env_name }}"
@@ -172,7 +179,18 @@ jobs:
           ACTOR="${{ github.actor }}"
           DATE=$(date +'%d %b %Y %H:%M IST')
 
+          # Determine if the action step actually succeeded
           if [ "$ACTION" = "add" ]; then
+            STEP_OUTCOME="$ADD_OUTCOME"
+          else
+            STEP_OUTCOME="$REMOVE_OUTCOME"
+          fi
+
+          if [ "$STEP_OUTCOME" != "success" ]; then
+            ICON=":warning:"
+            TITLE="MinIO Env Change Failed"
+            DETAIL="Action \`$ACTION\` for \`$ENV\` failed. Check the run for details."
+          elif [ "$ACTION" = "add" ]; then
             if [ "${ENV_STATUS:-added}" = "updated" ]; then
               ICON=":arrows_counterclockwise:"
               TITLE="MinIO Env Secrets Rotated"

--- a/.github/workflows/manage-env.yml
+++ b/.github/workflows/manage-env.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Read current MINIO_ENVS
         id: read_envs
         env:
-          GH_TOKEN: ${{ secrets.MANAGE_ENV_TOKEN }}
+          GH_TOKEN: ${{ secrets.ACTION_PAT }}
         run: |
           RAW=$(gh api \
             -H "Accept: application/vnd.github+json" \
@@ -70,7 +70,7 @@ jobs:
         id: add_env
         if: inputs.action == 'add'
         env:
-          GH_TOKEN:      ${{ secrets.MANAGE_ENV_TOKEN }}
+          GH_TOKEN:      ${{ secrets.ACTION_PAT }}
           ENV_NAME:      ${{ inputs.env_name }}
           CURRENT:       ${{ steps.read_envs.outputs.current }}
           MINIO_URL:     ${{ inputs.minio_url }}
@@ -136,7 +136,7 @@ jobs:
         id: remove_env
         if: inputs.action == 'remove'
         env:
-          GH_TOKEN:  ${{ secrets.MANAGE_ENV_TOKEN }}
+          GH_TOKEN:  ${{ secrets.ACTION_PAT }}
           ENV_NAME:  ${{ inputs.env_name }}
           CURRENT:   ${{ steps.read_envs.outputs.current }}
         run: |
@@ -182,7 +182,7 @@ jobs:
       - name: Notify Slack
         if: always()
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_URL: ${{ secrets.TEST_AUTOMATION_SLACK_WEBHOOK }}
           ADD_OUTCOME:       ${{ steps.add_env.outcome }}
           REMOVE_OUTCOME:    ${{ steps.remove_env.outcome }}
           ACTION:            ${{ inputs.action }}

--- a/.github/workflows/manage-env.yml
+++ b/.github/workflows/manage-env.yml
@@ -33,17 +33,20 @@ jobs:
 
     steps:
       - name: Validate inputs
+        env:
+          ACTION:        ${{ inputs.action }}
+          ENV_NAME:      ${{ inputs.env_name }}
+          MINIO_URL:     ${{ inputs.minio_url }}
+          MINIO_USER:    ${{ inputs.minio_user }}
+          MINIO_PASSWORD: ${{ inputs.minio_password }}
         run: |
-          ENV="${{ inputs.env_name }}"
-          ACTION="${{ inputs.action }}"
-
-          if [[ ! "$ENV" =~ ^[a-z0-9_-]+$ ]]; then
-            echo "Invalid env name '$ENV'. Use lowercase letters, numbers, hyphens, underscores only."
+          if [[ ! "$ENV_NAME" =~ ^[a-z0-9_-]+$ ]]; then
+            echo "Invalid env name '$ENV_NAME'. Use lowercase letters, numbers, hyphens, underscores only."
             exit 1
           fi
 
           if [ "$ACTION" = "add" ]; then
-            if [ -z "${{ inputs.minio_url }}" ] || [ -z "${{ inputs.minio_user }}" ] || [ -z "${{ inputs.minio_password }}" ]; then
+            if [ -z "$MINIO_URL" ] || [ -z "$MINIO_USER" ] || [ -z "$MINIO_PASSWORD" ]; then
               echo "minio_url, minio_user, and minio_password are all required for action=add."
               exit 1
             fi
@@ -59,7 +62,6 @@ jobs:
             /repos/${{ github.repository }}/actions/variables/MINIO_ENVS \
             --jq '.value')
 
-          # Compact to a single line so it writes cleanly to GITHUB_OUTPUT
           CURRENT=$(echo "$RAW" | jq -c '.')
           echo "Current MINIO_ENVS: $CURRENT"
           echo "current=$CURRENT" >> $GITHUB_OUTPUT
@@ -68,11 +70,15 @@ jobs:
         id: add_env
         if: inputs.action == 'add'
         env:
-          GH_TOKEN: ${{ secrets.MANAGE_ENV_TOKEN }}
+          GH_TOKEN:      ${{ secrets.MANAGE_ENV_TOKEN }}
+          ENV_NAME:      ${{ inputs.env_name }}
+          CURRENT:       ${{ steps.read_envs.outputs.current }}
+          MINIO_URL:     ${{ inputs.minio_url }}
+          MINIO_USER:    ${{ inputs.minio_user }}
+          MINIO_PASSWORD: ${{ inputs.minio_password }}
         run: |
-          ENV="${{ inputs.env_name }}"
-          CURRENT='${{ steps.read_envs.outputs.current }}'
-          ENV_UPPER=$(echo "$ENV" | tr '[:lower:]' '[:upper:]')
+          ENV="$ENV_NAME"
+          ENV_UPPER=$(echo "$ENV" | tr '[:lower:]' '[:upper:]' | tr '-' '_')
 
           EXISTS=$(echo "$CURRENT" | jq --arg env "$ENV" 'map(select(. == $env)) | length')
 
@@ -90,7 +96,7 @@ jobs:
             echo "ENV_STATUS=added" >> $GITHUB_ENV
           fi
 
-          pip install PyNaCl -q
+          pip install PyNaCl==1.5.0 -q
 
           KEY_DATA=$(gh api \
             -H "Accept: application/vnd.github+json" \
@@ -111,9 +117,9 @@ jobs:
             echo "Secret $SECRET_NAME set."
           }
 
-          encrypt_and_set "MINIO_${ENV_UPPER}_URL"      "${{ inputs.minio_url }}"
-          encrypt_and_set "MINIO_${ENV_UPPER}_USER"     "${{ inputs.minio_user }}"
-          encrypt_and_set "MINIO_${ENV_UPPER}_PASSWORD" "${{ inputs.minio_password }}"
+          encrypt_and_set "MINIO_${ENV_UPPER}_URL"      "$MINIO_URL"
+          encrypt_and_set "MINIO_${ENV_UPPER}_USER"     "$MINIO_USER"
+          encrypt_and_set "MINIO_${ENV_UPPER}_PASSWORD" "$MINIO_PASSWORD"
 
           echo "## Manage MinIO Environment" >> $GITHUB_STEP_SUMMARY
           if [ "$ENV_STATUS" = "added" ]; then
@@ -130,11 +136,12 @@ jobs:
         id: remove_env
         if: inputs.action == 'remove'
         env:
-          GH_TOKEN: ${{ secrets.MANAGE_ENV_TOKEN }}
+          GH_TOKEN:  ${{ secrets.MANAGE_ENV_TOKEN }}
+          ENV_NAME:  ${{ inputs.env_name }}
+          CURRENT:   ${{ steps.read_envs.outputs.current }}
         run: |
-          ENV="${{ inputs.env_name }}"
-          CURRENT='${{ steps.read_envs.outputs.current }}'
-          ENV_UPPER=$(echo "$ENV" | tr '[:lower:]' '[:upper:]')
+          ENV="$ENV_NAME"
+          ENV_UPPER=$(echo "$ENV" | tr '[:lower:]' '[:upper:]' | tr '-' '_')
 
           EXISTS=$(echo "$CURRENT" | jq --arg env "$ENV" 'map(select(. == $env)) | length')
           if [ "$EXISTS" -eq 0 ]; then
@@ -176,16 +183,16 @@ jobs:
         if: always()
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-          ADD_OUTCOME:    ${{ steps.add_env.outcome }}
-          REMOVE_OUTCOME: ${{ steps.remove_env.outcome }}
+          ADD_OUTCOME:       ${{ steps.add_env.outcome }}
+          REMOVE_OUTCOME:    ${{ steps.remove_env.outcome }}
+          ACTION:            ${{ inputs.action }}
+          ENV_NAME:          ${{ inputs.env_name }}
+          ACTOR_NAME:        ${{ github.actor }}
+          RUN_URL:           ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          ACTION="${{ inputs.action }}"
-          ENV="${{ inputs.env_name }}"
-          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          ACTOR="${{ github.actor }}"
+          ENV="$ENV_NAME"
           DATE=$(date +'%d %b %Y %H:%M IST')
 
-          # Determine if the action step actually succeeded
           if [ "$ACTION" = "add" ]; then
             STEP_OUTCOME="$ADD_OUTCOME"
           else
@@ -219,7 +226,7 @@ jobs:
           PAYLOAD=$(jq -n \
             --arg title "$ICON $TITLE" \
             --arg detail "$DETAIL" \
-            --arg actor "Triggered by: $ACTOR" \
+            --arg actor "Triggered by: $ACTOR_NAME" \
             --arg date "$DATE" \
             --arg url "$RUN_URL" \
             '{

--- a/.github/workflows/manage-env.yml
+++ b/.github/workflows/manage-env.yml
@@ -1,0 +1,255 @@
+name: Manage MinIO Environment
+
+on:
+  workflow_dispatch:
+    inputs:
+      action:
+        description: 'Action to perform'
+        required: true
+        type: choice
+        options:
+          - add
+          - remove
+      env_name:
+        description: 'Environment name (e.g. qa22) — must be lowercase'
+        required: true
+        type: string
+      minio_url:
+        description: 'MinIO URL (required for add)'
+        required: false
+        type: string
+      minio_user:
+        description: 'MinIO username (required for add)'
+        required: false
+        type: string
+      minio_password:
+        description: 'MinIO password (required for add)'
+        required: false
+        type: string
+
+jobs:
+  manage-env:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Validate inputs
+        run: |
+          ENV="${{ inputs.env_name }}"
+          ACTION="${{ inputs.action }}"
+
+          if [[ ! "$ENV" =~ ^[a-z0-9_-]+$ ]]; then
+            echo "Invalid env name '$ENV'. Use lowercase letters, numbers, hyphens, underscores only."
+            exit 1
+          fi
+
+          if [ "$ACTION" = "add" ]; then
+            if [ -z "${{ inputs.minio_url }}" ] || [ -z "${{ inputs.minio_user }}" ] || [ -z "${{ inputs.minio_password }}" ]; then
+              echo "minio_url, minio_user, and minio_password are all required for action=add."
+              exit 1
+            fi
+          fi
+
+      - name: Read current MINIO_ENVS
+        id: read_envs
+        env:
+          GH_TOKEN: ${{ secrets.MANAGE_ENV_TOKEN }}
+        run: |
+          CURRENT=$(gh api \
+            -H "Accept: application/vnd.github+json" \
+            /repos/${{ github.repository }}/actions/variables/MINIO_ENVS \
+            --jq '.value')
+
+          echo "Current MINIO_ENVS: $CURRENT"
+          echo "current=$CURRENT" >> $GITHUB_OUTPUT
+
+      - name: Add environment
+        if: inputs.action == 'add'
+        env:
+          GH_TOKEN: ${{ secrets.MANAGE_ENV_TOKEN }}
+        run: |
+          ENV="${{ inputs.env_name }}"
+          CURRENT='${{ steps.read_envs.outputs.current }}'
+          ENV_UPPER=$(echo "$ENV" | tr '[:lower:]' '[:upper:]')
+
+          # Check if env already exists — if so, skip variable update and only rotate secrets
+          EXISTS=$(echo "$CURRENT" | jq --arg env "$ENV" 'map(select(. == $env)) | length')
+
+          if [ "$EXISTS" -gt 0 ]; then
+            echo "::warning::Environment '$ENV' already exists in MINIO_ENVS — variable unchanged. Secrets will be updated."
+            echo "ENV_STATUS=updated" >> $GITHUB_ENV
+          else
+            # Add env to the list and update the variable
+            UPDATED=$(echo "$CURRENT" | jq --arg env "$ENV" '. + [$env]')
+            echo "Updated MINIO_ENVS: $UPDATED"
+            gh api \
+              -X PATCH \
+              -H "Accept: application/vnd.github+json" \
+              /repos/${{ github.repository }}/actions/variables/MINIO_ENVS \
+              -f value="$UPDATED"
+            echo "ENV_STATUS=added" >> $GITHUB_ENV
+          fi
+
+          # Get repo public key for secret encryption
+          KEY_DATA=$(gh api \
+            -H "Accept: application/vnd.github+json" \
+            /repos/${{ github.repository }}/actions/secrets/public-key)
+          KEY_ID=$(echo "$KEY_DATA" | jq -r '.key_id')
+          KEY=$(echo "$KEY_DATA" | jq -r '.key')
+
+          # Encrypt and create each secret using Python (libsodium via PyNaCl)
+          pip install PyNaCl -q
+
+          encrypt_and_set() {
+            SECRET_NAME=$1
+            SECRET_VALUE=$2
+
+            ENCRYPTED=$(python3 - "$KEY" "$SECRET_VALUE" << 'PYEOF'
+import sys, base64
+from nacl import encoding, public
+
+key   = base64.b64decode(sys.argv[1])
+value = sys.argv[2].encode()
+box   = public.SealedBox(public.PublicKey(key))
+print(base64.b64encode(box.encrypt(value)).decode())
+PYEOF
+)
+            gh api \
+              -X PUT \
+              -H "Accept: application/vnd.github+json" \
+              /repos/${{ github.repository }}/actions/secrets/$SECRET_NAME \
+              -f encrypted_value="$ENCRYPTED" \
+              -f key_id="$KEY_ID"
+
+            echo "Secret $SECRET_NAME created."
+          }
+
+          encrypt_and_set "MINIO_${ENV_UPPER}_URL"      "${{ inputs.minio_url }}"
+          encrypt_and_set "MINIO_${ENV_UPPER}_USER"     "${{ inputs.minio_user }}"
+          encrypt_and_set "MINIO_${ENV_UPPER}_PASSWORD" "${{ inputs.minio_password }}"
+
+          if [ "$ENV_STATUS" = "added" ]; then
+            echo "Environment '$ENV' added to MINIO_ENVS and secrets created."
+            echo "MINIO_ENVS is now: $UPDATED"
+          else
+            echo "Environment '$ENV' already existed — MINIO_ENVS unchanged. Secrets rotated."
+          fi
+
+          echo "## Manage MinIO Environment" >> $GITHUB_STEP_SUMMARY
+          if [ "$ENV_STATUS" = "added" ]; then
+            echo "**Action:** Add" >> $GITHUB_STEP_SUMMARY
+            echo "**Environment:** \`$ENV\`" >> $GITHUB_STEP_SUMMARY
+            echo "**Result:** Added to MINIO_ENVS and secrets created." >> $GITHUB_STEP_SUMMARY
+          else
+            echo "**Action:** Add (secret rotation)" >> $GITHUB_STEP_SUMMARY
+            echo "**Environment:** \`$ENV\`" >> $GITHUB_STEP_SUMMARY
+            echo "**Result:** \`$ENV\` already existed in MINIO_ENVS — variable was not modified. Secrets MINIO_${ENV_UPPER}_URL / _USER / _PASSWORD have been replaced." >> $GITHUB_STEP_SUMMARY
+          fi
+
+      - name: Notify Slack
+        if: always()
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          ACTION="${{ inputs.action }}"
+          ENV="${{ inputs.env_name }}"
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          ACTOR="${{ github.actor }}"
+          DATE=$(date +'%d %b %Y %H:%M IST')
+
+          if [ "$ACTION" = "add" ]; then
+            if [ "${ENV_STATUS:-added}" = "updated" ]; then
+              ICON=":arrows_counterclockwise:"
+              TITLE="MinIO Env Secrets Rotated"
+              DETAIL="\`$ENV\` already existed — MINIO_ENVS unchanged. Secrets have been replaced."
+            else
+              ICON=":white_check_mark:"
+              TITLE="MinIO Env Added"
+              DETAIL="\`$ENV\` has been added to MINIO_ENVS and its secrets created."
+            fi
+          else
+            ICON=":x:"
+            TITLE="MinIO Env Removed"
+            DETAIL="\`$ENV\` has been removed from MINIO_ENVS and its secrets deleted."
+          fi
+
+          PAYLOAD=$(jq -n \
+            --arg title "$ICON $TITLE" \
+            --arg detail "$DETAIL" \
+            --arg actor "Triggered by: $ACTOR" \
+            --arg date "$DATE" \
+            --arg url "$RUN_URL" \
+            '{
+              blocks: [
+                {
+                  type: "header",
+                  text: { type: "plain_text", text: $title, emoji: true }
+                },
+                {
+                  type: "section",
+                  text: { type: "mrkdwn", text: $detail }
+                },
+                {
+                  type: "context",
+                  elements: [
+                    { type: "mrkdwn", text: $actor },
+                    { type: "mrkdwn", text: $date }
+                  ]
+                },
+                { type: "divider" },
+                {
+                  type: "actions",
+                  elements: [
+                    {
+                      type: "button",
+                      text: { type: "plain_text", text: "View Run", emoji: true },
+                      url: $url,
+                      style: "primary"
+                    }
+                  ]
+                }
+              ]
+            }')
+
+          curl -fsSL -X POST -H 'Content-type: application/json' \
+               --data "$PAYLOAD" "$SLACK_WEBHOOK_URL"
+
+      - name: Remove environment
+        if: inputs.action == 'remove'
+        env:
+          GH_TOKEN: ${{ secrets.MANAGE_ENV_TOKEN }}
+        run: |
+          ENV="${{ inputs.env_name }}"
+          CURRENT='${{ steps.read_envs.outputs.current }}'
+          ENV_UPPER=$(echo "$ENV" | tr '[:lower:]' '[:upper:]')
+
+          # Check env exists
+          EXISTS=$(echo "$CURRENT" | jq --arg env "$ENV" 'map(select(. == $env)) | length')
+          if [ "$EXISTS" -eq 0 ]; then
+            echo "Environment '$ENV' not found in MINIO_ENVS. Nothing to do."
+            exit 1
+          fi
+
+          # Remove env from the list
+          UPDATED=$(echo "$CURRENT" | jq --arg env "$ENV" 'map(select(. != $env))')
+          echo "Updated MINIO_ENVS: $UPDATED"
+
+          # Update the variable
+          gh api \
+            -X PATCH \
+            -H "Accept: application/vnd.github+json" \
+            /repos/${{ github.repository }}/actions/variables/MINIO_ENVS \
+            -f value="$UPDATED"
+
+          # Delete the 3 secrets
+          for SUFFIX in URL USER PASSWORD; do
+            SECRET_NAME="MINIO_${ENV_UPPER}_${SUFFIX}"
+            gh api \
+              -X DELETE \
+              -H "Accept: application/vnd.github+json" \
+              /repos/${{ github.repository }}/actions/secrets/$SECRET_NAME \
+              && echo "Secret $SECRET_NAME deleted." \
+              || echo "Secret $SECRET_NAME not found, skipping."
+          done
+
+          echo "Environment '$ENV' removed successfully."
+          echo "MINIO_ENVS is now: $UPDATED"

--- a/.github/workflows/update-reports.yml
+++ b/.github/workflows/update-reports.yml
@@ -309,7 +309,7 @@ jobs:
       - name: Notify Slack on failure
         if: ${{ env.FAILED_ENVS != '' }}
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_URL: ${{ secrets.TEST_AUTOMATION_SLACK_WEBHOOK }}
         run: |
           RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           DATE=$(date +'%d %b %Y')


### PR DESCRIPTION
A manually triggered workflow that adds or removes a MinIO environment from the reporting pipeline. Manages both the MINIO_ENVS variable (which drives the matrix in update-reports-1.yml) and the associated secrets in one operation — replacing manual edits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New automated MinIO environment management workflow for seamless configuration control
  * Administrators can securely add or remove MinIO environments through manual workflow triggers
  * Built-in validation prevents configuration errors and maintains system integrity
  * Real-time Slack notifications ensure operational transparency for environment management activities

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mosip/test-management/pull/215?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->